### PR TITLE
fix shuffling

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'word-game'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=word-game",
+                    "--package=word-game"
+                ],
+                "filter": {
+                    "name": "word-game",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'word-game'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=word-game",
+                    "--package=word-game"
+                ],
+                "filter": {
+                    "name": "word-game",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/src/word.rs
+++ b/src/word.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::{seq::SliceRandom};
 pub struct Word(String);
 
 impl Word {
@@ -15,13 +15,11 @@ impl Word {
     }
 
     fn shuffle(&mut self) {
-        let mut shuffled_word = String::new();
         let mut rng = rand::thread_rng();
-        while self.get_string().len() > 0 {
-            let index = rng.gen_range(0..self.get_string().len());
-            shuffled_word.push(self.get_string().to_string().remove(index));
-        }
-        self.set_string(shuffled_word.to_uppercase().as_str());
+        let mut word: Vec<_> = self.get_string().chars().collect();
+        word.shuffle(&mut rng);
+        let shuffled: String = word.into_iter().collect();
+        self.set_string(shuffled.as_str());
     }
 
     pub fn format(&mut self, separator: Option<char>) -> String {


### PR DESCRIPTION
Using an index for shuffling fails if the word contains non ASCII characters. e.g. `bactérien`.